### PR TITLE
Notifications: switched to using lime.system.JNI

### DIFF
--- a/extension/notifications/Notifications.hx
+++ b/extension/notifications/Notifications.hx
@@ -1,7 +1,7 @@
 package extension.notifications;
 
 #if android
-import openfl.utils.JNI;
+import lime.system.JNI;
 #end
 
 #if ios


### PR DESCRIPTION
This PR allows using this extension on Android while using the latest OpenFl/Lime.